### PR TITLE
Add Flask-Mailman

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@
 ### Email
 
 - [Flask-Mail](https://pythonhosted.org/Flask-Mail/) - Provides simple email sending capabilities.
+- [Flask-Mailman](https://pypi.org/project/flask-mailman/) - A port of `django.mail` for Flask.
 
 ### Forms
 


### PR DESCRIPTION
From the authors website: "Flask-Mailman is a Flask extension providing simple email sending capabilities.
It was meant to replace unmaintained Flask-Mail with a better warranty and more features."